### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/terraform-Blue-Deployment-part1.yml
+++ b/.github/workflows/terraform-Blue-Deployment-part1.yml
@@ -103,7 +103,7 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vichnik/docker-image
         username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/terraform-Green-Deployment.yml
+++ b/.github/workflows/terraform-Green-Deployment.yml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: vichnik/docker-image
         username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore